### PR TITLE
Link Berlin Code of Conduct

### DIFF
--- a/join.html
+++ b/join.html
@@ -14,7 +14,7 @@ section: join
     <h1>Dołącz do nas!</h1>
   </header>
   <p>WRUG to koleżeńska, nieformalna i oddolna wymiana wiedzy, umiejętności, doświadczeń. Zachęcamy do zadawania pytań w trakcie prezentacji i do dyskusji po ich zakończeniu. Po części oficjalnej schodzimy piętro niżej: z Fundacji Cyfrowej do Państwamiasta, w którym można porozmawiać o programowaniu (i nie tylko!) w mniej zobowiązującej atmosferze.</p>
-  <p>Chcesz opowiedzieć o czymś na WRUGu? <b>Zachęcamy do zgłaszania prezentacji!</b> Ponieważ publiczność jest różna, kładziemy nacisk na wystąpienia o różnym poziomie zaawansowania. Zależy nam, aby WRUG za każdym razem odbywał się w przyjaznej atmosferze. Do udziału zapraszamy <b>wszystkich,</b> niezależnie od umiejętności programowania, wieku, płci, czy czegokolwiek innego.</p>
+  <p>Chcesz opowiedzieć o czymś na WRUG-u? <b>Zachęcamy do zgłaszania prezentacji!</b> Ponieważ publiczność jest różna, kładziemy nacisk na wystąpienia o różnym poziomie zaawansowania. Zależy nam, aby WRUG za każdym razem odbywał się w przyjaznej atmosferze. Do udziału zapraszamy <b>wszystkich</b>, niezależnie od umiejętności programowania, wieku, płci, czy czegokolwiek innego; <b>oferujemy pomoc i prosimy o zachowywanie się zgodnie z <a href='http://rubyberlin.github.io/code-of-conduct/pl/'>Berlińskim kodeksem postępowania</a></b>.</p>
 </article>
 <article class="news">
   <h1>Chcesz zgłosić prezentację?</h1>


### PR DESCRIPTION
This links the Berlin Code of Conduct from the ‘Join!’ page.
